### PR TITLE
デプスの比較時、プリプロセッサによる条件分岐を入れる

### DIFF
--- a/Assets/ScreenSpaceBoolean/Shaders/Mask.shader
+++ b/Assets/ScreenSpaceBoolean/Shaders/Mask.shader
@@ -38,7 +38,7 @@ sampler2D _SubtracteeBackDepth;
 v2f vert(appdata v)
 {
     v2f o;
-    o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+    o.vertex = UnityObjectToClipPos(v.vertex);
     o.spos = ComputeScreenPos(o.vertex);
     return o;
 }
@@ -54,10 +54,15 @@ gbuffer_out frag_depth(v2f i)
     float subtracteeBackDepth = tex2D(_SubtracteeBackDepth, uv);
     float subtractorBackDepth = ComputeDepth(i.spos);
 
-    if (subtractorBackDepth <= subtracteeBackDepth) discard; 
-
-    gbuffer_out o;
-    o.color = o.depth = 1.0;
+	gbuffer_out o;
+#if defined(UNITY_REVERSED_Z)
+    if (subtractorBackDepth >= subtracteeBackDepth) discard;
+	o.color = o.depth = 0.0;
+#else
+	if (subtractorBackDepth <= subtracteeBackDepth) discard;
+	o.color = o.depth = 1.0;
+#endif
+    
     return o;
 }
 ENDCG

--- a/Assets/ScreenSpaceBoolean/Shaders/Mask.shader
+++ b/Assets/ScreenSpaceBoolean/Shaders/Mask.shader
@@ -54,13 +54,13 @@ gbuffer_out frag_depth(v2f i)
     float subtracteeBackDepth = tex2D(_SubtracteeBackDepth, uv);
     float subtractorBackDepth = ComputeDepth(i.spos);
 
-	gbuffer_out o;
+    gbuffer_out o;
 #if defined(UNITY_REVERSED_Z)
     if (subtractorBackDepth >= subtracteeBackDepth) discard;
-	o.color = o.depth = 0.0;
+    o.color = o.depth = 0.0;
 #else
-	if (subtractorBackDepth <= subtracteeBackDepth) discard;
-	o.color = o.depth = 1.0;
+    if (subtractorBackDepth <= subtracteeBackDepth) discard;
+    o.color = o.depth = 1.0;
 #endif
     
     return o;


### PR DESCRIPTION
issue #1 と直接関係しているかわかりませんが、この修正を施すと、ひとまず正常と見える挙動となるようです。